### PR TITLE
fix: prevent race condition when rapidly pressing cmd+q on macOS

### DIFF
--- a/src/main/ipcBridge.ts
+++ b/src/main/ipcBridge.ts
@@ -133,13 +133,21 @@ export function registerIpcHandleHandlers(win: Electron.BrowserWindow) {
 }
 
 export function close(win: Electron.BrowserWindow) {
+  // 防止重复调用
+  if (isQuitting) {
+    return
+  }
+
   if (isSaved) {
     isQuitting = true
     win.close()
     app.quit()
   } else {
-    // 发送事件到渲染进程显示前端弹窗
-    win.webContents.send('close:confirm')
+    // 检查窗口是否仍然有效
+    if (win && !win.isDestroyed()) {
+      // 发送事件到渲染进程显示前端弹窗
+      win.webContents.send('close:confirm')
+    }
   }
 }
 


### PR DESCRIPTION
## 问题描述
在 macOS 上连续快速按 `cmd+q` 时会导致主进程报错，原因是存在竞态条件。

## 修复内容
- 添加防重入保护，防止 `close()` 函数被重复调用
- 添加窗口有效性检查，避免对已销毁窗口的操作
- 对所有平台（Windows/Linux/macOS）都安全且有益

## 测试
- ✅ macOS：解决连续 cmd+q 导致的崩溃问题
- ✅ Windows/Linux：保持原有行为，增加稳定性

## 变更类型
- [x] Bug 修复
- [ ] 新功能
- [ ] 破坏性变更
- [ ] 文档更新