### PR TITLE
Fix markdown rendering on macos startup

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ import createMenu from './menu'
 
 let win: BrowserWindow
 let themeEditorWindow: BrowserWindow | null = null
+let pendingOpenFilePath: string | null = null
 
 async function createWindow() {
   win = new BrowserWindow({
@@ -94,25 +95,57 @@ function sendLaunchFileIfExists() {
   const fileArg = process.argv.find(arg => arg.endsWith('.md') || arg.endsWith('.markdown'))
 
   if (fileArg) {
-    const absolutePath = path.resolve(fileArg)
-    if (fs.existsSync(absolutePath)) {
-      const content = fs.readFileSync(absolutePath, 'utf-8')
-      win.webContents.send('open-file-at-launch', {
-        filePath: absolutePath,
-        content,
-      })
-    } else {
-      console.warn('[main] 文件不存在:', absolutePath)
-    }
+    openFileInRenderer(fileArg)
   }
 }
+
+function openFileInRenderer(filePath: string) {
+  const absolutePath = path.resolve(filePath)
+  if (!win || win.isDestroyed())
+    return
+  if (fs.existsSync(absolutePath)) {
+    const content = fs.readFileSync(absolutePath, 'utf-8')
+    win.webContents.send('open-file-at-launch', {
+      filePath: absolutePath,
+      content,
+    })
+  } else {
+    console.warn('[main] 文件不存在:', absolutePath)
+  }
+}
+
+// macOS: 捕获通过 Finder 打开的文件（可能发生在 ready 之前）
+app.on('open-file', (event, filePath) => {
+  event.preventDefault()
+  if (app.isReady() && win) {
+    // 应用已就绪，直接分发到渲染进程
+    if (win.isMinimized())
+      win.restore()
+    if (!win.isVisible())
+      win.show()
+    win.focus()
+    openFileInRenderer(filePath)
+  } else {
+    // 尚未 ready，先缓存，待窗口加载完成后再发送
+    pendingOpenFilePath = filePath
+  }
+})
 
 app.whenReady().then(async () => {
   await createWindow()
   createMenu(win)
-  sendLaunchFileIfExists()
   registerIpcOnHandlers(win)
   registerIpcHandleHandlers(win)
+  // 确保在页面完成加载后再把待打开的文件发送给渲染进程，避免监听尚未注册导致丢失
+  win.webContents.once('did-finish-load', () => {
+    if (pendingOpenFilePath) {
+      openFileInRenderer(pendingOpenFilePath)
+      pendingOpenFilePath = null
+    } else {
+      // 非 macOS 或通过命令行/关联打开的文件（Windows/Linux）
+      sendLaunchFileIfExists()
+    }
+  })
   win.on('close', (event) => {
     if (process.platform === 'darwin' && !getIsQuitting()) {
       event.preventDefault()


### PR DESCRIPTION
Add macOS `open-file` event handling and delay file content dispatch to fix cold start rendering issues.

On macOS, the `open-file` event can be triggered before the Electron app is fully ready and the renderer process has loaded its content and registered its IPC listeners. This caused the file content to not be rendered when the app was launched by double-clicking a file. This PR caches the file path and dispatches it to the renderer only after the window's `did-finish-load` event, ensuring the renderer is ready to receive and display the content.

---
<a href="https://cursor.com/background-agent?bcId=bc-1684b349-b763-480f-b282-942260dc6cd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1684b349-b763-480f-b282-942260dc6cd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

